### PR TITLE
Allow containers 0.6, as released with GHC 8.6.

### DIFF
--- a/text-metrics.cabal
+++ b/text-metrics.cabal
@@ -26,7 +26,7 @@ flag dev
 
 library
   build-depends:      base             >= 4.7 && < 5.0
-                    , containers       >= 0.5 && < 0.6
+                    , containers       >= 0.5 && < 0.7
                     , text             >= 0.2 && < 1.3
                     , vector           >= 0.11 && < 0.13
   exposed-modules:    Data.Text.Metrics


### PR DESCRIPTION
After this is merged, a release or revision would be handy, please.