### PR TITLE
Fix incorrect results for strings with long common prefixes

### DIFF
--- a/Data/Text/Metrics.hs
+++ b/Data/Text/Metrics.hs
@@ -348,7 +348,7 @@ jaroWinkler a b = dj + (1 % 10) * l * (1 - dj)
 
 -- | Return the length of the common prefix two 'Text' values have.
 commonPrefix :: Text -> Text -> Int
-commonPrefix a b = go 0 0 0
+commonPrefix a b = min 4 $ go 0 0 0
   where
     go !na !nb !r =
       let !(TU.Iter cha da) = TU.iter a na

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -105,6 +105,8 @@ spec = do
     testPair jaroWinkler "lucky" "lucky" (1 % 1)
     testPair jaroWinkler "a😀c" "abc" (4 % 5)
     testPair jaroWinkler "" "" (0 % 1)
+    testPair jaroWinkler "aaaaaaaaaab" "aaaaaaaaaa" (54 % 55)
+    testPair jaroWinkler "aaaaaaaaaaaaaaaaaaaab" "aaaaaaaaaaaaaaaaaaaa" (104 % 105)
   describe "overlap" $ do
     testSwap overlap
     testPair overlap "fly" "butterfly" (1 % 1)


### PR DESCRIPTION
This PR fixes a problem with the jaro-winkler implementation that
would lead to incorrect results where the function would return a
value >= 1.0 for different strings with a long common prefix.