### PR TITLE
Support text-2.0

### DIFF
--- a/text-metrics.cabal
+++ b/text-metrics.cabal
@@ -31,7 +31,7 @@ library
     build-depends:
         base >=4.13 && <5.0,
         containers >=0.5 && <0.7,
-        text >=0.2 && <1.3,
+        text >=0.2 && <2.1,
         vector >=0.11 && <0.13
 
     if flag(dev)
@@ -49,7 +49,7 @@ test-suite tests
         QuickCheck >=2.8 && <3.0,
         base >=4.13 && <5.0,
         hspec >=2.0 && <3.0,
-        text >=0.2 && <1.3,
+        text >=0.2 && <2.1,
         text-metrics
 
     if flag(dev)
@@ -72,7 +72,7 @@ benchmark bench-speed
         base >=4.13 && <5.0,
         criterion >=0.6.2.1 && <1.6,
         deepseq >=1.3 && <1.5,
-        text >=0.2 && <1.3,
+        text >=0.2 && <2.1,
         text-metrics
 
     if flag(dev)
@@ -89,7 +89,7 @@ benchmark bench-memory
     build-depends:
         base >=4.13 && <5.0,
         deepseq >=1.3 && <1.5,
-        text >=0.2 && <1.3,
+        text >=0.2 && <2.1,
         text-metrics,
         weigh >=0.0.4
 


### PR DESCRIPTION
Tested with 
```cabal
packages: .
constraints: text >= 2.0

-- For benchmarks:

tests: True
benchmarks: True

allow-newer: *:text

source-repository-package
  type: git
  location: https://github.com/haskell/aeson
```