### PR TITLE
Optimise levenshtein

### DIFF
--- a/Data/Text/Metrics.hs
+++ b/Data/Text/Metrics.hs
@@ -46,6 +46,7 @@ import Data.Text qualified as T
 import Data.Text.Internal qualified as T
 import Data.Text.Unsafe qualified as TU
 import Data.Vector.Unboxed.Mutable qualified as VUM
+import Data.Primitive qualified as P
 import GHC.Exts (inline)
 
 ----------------------------------------------------------------------------
@@ -85,29 +86,34 @@ levenshtein_ a b
   | T.null b = (lena, lenm)
   | otherwise = runST $ do
       let v_len = lenb + 1
-      v <- VUM.unsafeNew (v_len * 2)
+      v <- P.newPrimArray (v_len * 2)
       let gov !i =
             when (i < v_len) $ do
-              VUM.unsafeWrite v i i
+              P.writePrimArray v i i
               gov (i + 1)
           goi !i !na !v0 !v1 = do
             let !(TU.Iter ai da) = TU.iter a na
                 goj !j !nb =
                   when (j < lenb) $ do
                     let !(TU.Iter bj db) = TU.iter b nb
-                        cost = if ai == bj then 0 else 1
-                    x <- (+ 1) <$> VUM.unsafeRead v (v1 + j)
-                    y <- (+ 1) <$> VUM.unsafeRead v (v0 + j + 1)
-                    z <- (+ cost) <$> VUM.unsafeRead v (v0 + j)
-                    VUM.unsafeWrite v (v1 + j + 1) (min x (min y z))
-                    goj (j + 1) (nb + db)
+                    if ai == bj
+                    then do
+                      z <- P.readPrimArray v (v0 + j)
+                      P.writePrimArray v (v1 + j + 1) z
+                      goj (j + 1) (nb + db)
+                    else  do
+                      x <- P.readPrimArray v (v1 + j)
+                      y <- P.readPrimArray v (v0 + j + 1)
+                      z <- P.readPrimArray v (v0 + j)
+                      P.writePrimArray v (v1 + j + 1) (1 + (min x (min y z)))
+                      goj (j + 1) (nb + db)
             when (i < lena) $ do
-              VUM.unsafeWrite v v1 (i + 1)
+              P.writePrimArray v v1 (i + 1)
               goj 0 0
               goi (i + 1) (na + da) v1 v0
       gov 0
       goi 0 0 0 v_len
-      ld <- VUM.unsafeRead v (lenb + if even lena then 0 else v_len)
+      ld <- P.readPrimArray v (lenb + if even lena then 0 else v_len)
       return (ld, lenm)
   where
     lena = T.length a

--- a/text-metrics.cabal
+++ b/text-metrics.cabal
@@ -32,7 +32,8 @@ library
         base >=4.15 && <5,
         containers >=0.5 && <0.8,
         text >=0.2 && <2.2,
-        vector >=0.11 && <0.14
+        vector >=0.11 && <0.14,
+        primitive >=0.9 && <0.10
 
     if flag(dev)
         ghc-options:


### PR DESCRIPTION
- if characters are the same, use diagonal directly.
- Use primitive instead of vector  we don't need splices, saves a bit)

Improves levenshtein benchmarks by about 6-12% on my machine.